### PR TITLE
Add location email trigger via shake or command

### DIFF
--- a/OK workspaces/hecate.py
+++ b/OK workspaces/hecate.py
@@ -197,6 +197,17 @@ class Hecate:
             except Exception:
                 return f"{self.name}: Use 'location:lat|lon|email'"
 
+        elif user_input.startswith("sendlocation:"):
+            try:
+                lat, lon = user_input.split("sendlocation:", 1)[1].split("|", 1)
+                self.current_location = (lat.strip(), lon.strip())
+            except ValueError:
+                return f"{self.name}: Use 'sendlocation:lat|lon'"
+            return self._send_distress_email()
+
+        elif user_input.lower() in ["send location", "send my location", "share location", "share my location"]:
+            return self._send_distress_email()
+
         elif user_input.startswith("learn:"):
             content = user_input.split("learn:", 1)[1].strip()
             return self._learn_from_text(content)
@@ -547,6 +558,17 @@ class Hecate:
             return f"{self.name}: Email sent to {to_addr}."
         except Exception as e:
             return f"{self.name}: Failed to send email:\n{e}"
+
+    def _send_distress_email(self):
+        to = os.getenv("DISTRESS_EMAIL")
+        if not self.current_location:
+            return f"{self.name}: No location available."
+        if not to:
+            return f"{self.name}: No emergency contact configured."
+        lat, lon = self.current_location
+        subject = "Location Data"
+        body = f"Latitude: {lat}\nLongitude: {lon}"
+        return self._send_email(to, subject, body)
 
     def _fetch_emails(self, count=5):
         if not (self.gmail_user and self.gmail_pass):

--- a/README.md
+++ b/README.md
@@ -164,6 +164,9 @@ email the saved location to this address.
 Hecate also listens for certain distress phrases such as "help", "help me", "I'm scared",
 "I'll call my dad", "stop it now", and "leave me alone". Saying or typing any of these will
 trigger the same emergency email with your tagged location.
+You can also manually send the tagged location by saying "send location" in the chat
+or by shaking your phone in the browser interface. The shake gesture triggers the
+same distress email using your stored coordinates.
 
 ### Running from a zipped archive
 You can bundle Hecate into a single executable zip using Python's `zipapp` module. First make sure `__main__.py` is present (it runs the server). Create the archive:

--- a/index.html
+++ b/index.html
@@ -174,6 +174,24 @@
     appendReply(message, reply);
   }
 
+  async function sendDistressLocation() {
+    if (!currentLocation) {
+      alert("No location captured yet.");
+      return;
+    }
+    const message = `sendlocation:${currentLocation.latitude}|${currentLocation.longitude}`;
+    const res = await fetch("http://localhost:8080/talk", {
+      method: "POST",
+      headers: {"Content-Type": "application/json"},
+      body: JSON.stringify({ message })
+    });
+    const data = await res.json();
+    const reply = data.reply;
+    document.getElementById("response").innerText = reply;
+    speak(reply);
+    appendReply("sendlocation", reply);
+  }
+
   async function summarizeMemory() {
     const res = await fetch("http://localhost:8080/talk", {
       method: "POST",
@@ -222,6 +240,19 @@
     }
     window.addEventListener('DOMContentLoaded', () => {
       getLocation();
+      let lastShake = 0;
+      window.addEventListener('devicemotion', e => {
+        const acc = e.accelerationIncludingGravity;
+        if (!acc) return;
+        const mag = Math.sqrt(acc.x * acc.x + acc.y * acc.y + acc.z * acc.z);
+        if (mag > 25) {
+          const now = Date.now();
+          if (now - lastShake > 1000) {
+            lastShake = now;
+            sendDistressLocation();
+          }
+        }
+      });
       fetch('http://localhost:8080/talk', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },


### PR DESCRIPTION
## Summary
- allow sending emergency location with `sendlocation:` or by saying 'send location'
- notify emergency contact from a phone shake
- document new distress location options

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0 echo)`

------
https://chatgpt.com/codex/tasks/task_e_68897b4a8018832f966f533dd1fbf69b