### PR TITLE
Add MandemOS frontend

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,3 +212,24 @@ python insert_metadata.py
 
 This inserts the scroll information from `metadata.json` into the `scrolls` table.
 
+### MandemOS Frontend
+The repository now includes a minimal Node.js front end located in
+`mandemos_frontend/`. It serves a simple status page for MandemOS and
+can be used alongside the Flask API.
+
+1. Install the dependencies:
+
+   ```bash
+   cd mandemos_frontend
+   npm install
+   ```
+
+2. Start the web server:
+
+   ```bash
+   npm start
+   ```
+
+   The page will be available at `http://localhost:3000` and should display
+   **"MandemOS Clone Active"**.
+

--- a/mandemos_frontend/.github/workflows/build.yml
+++ b/mandemos_frontend/.github/workflows/build.yml
@@ -1,0 +1,22 @@
+name: Build EXE
+
+on:
+  push:
+    branches: [ main ]
+
+jobs:
+  build-windows:
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '18'
+      - run: npm install
+      - run: npm install -g pkg
+      - run: pkg server.js --targets node18-win-x64 --output MandemOS_Launcher.exe
+      - uses: actions/upload-artifact@v3
+        with:
+          name: MandemOS_Launcher
+          path: MandemOS_Launcher.exe

--- a/mandemos_frontend/build.js
+++ b/mandemos_frontend/build.js
@@ -1,0 +1,2 @@
+#!/usr/bin/env node
+console.log("MandemOS EXE launcher ready.");

--- a/mandemos_frontend/package.json
+++ b/mandemos_frontend/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "mandemos-clone",
+  "version": "1.0.0",
+  "description": "MandemOS Universal Clone",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "dependencies": {
+    "express": "^4.18.2"
+  }
+}

--- a/mandemos_frontend/public/index.html
+++ b/mandemos_frontend/public/index.html
@@ -1,0 +1,1 @@
+<!DOCTYPE html><html><head><title>MandemOS</title></head><body><h1>MandemOS Clone Active</h1></body></html>

--- a/mandemos_frontend/server.js
+++ b/mandemos_frontend/server.js
@@ -1,0 +1,13 @@
+const express = require('express');
+const path = require('path');
+const app = express();
+const PORT = 3000;
+
+app.use(express.static('public'));
+app.get('*', (req, res) => {
+  res.sendFile(path.resolve(__dirname, 'public', 'index.html'));
+});
+
+app.listen(PORT, () => {
+  console.log(`MandemOS Clone running on http://localhost:${PORT}`);
+});


### PR DESCRIPTION
## Summary
- add simple Node.js MandemOS frontend extracted from MandemOS_GitHub_Builder_Repo.zip
- document how to run the new frontend in README

## Testing
- `python -m py_compile $(git ls-files '*.py' | tr '\n' ' ')`

------
https://chatgpt.com/codex/tasks/task_e_6889c0de6c9c832f96e5d84a3a3801d5