### PR TITLE
Add response box to MandemOS UI

### DIFF
--- a/mandemos_frontend/public/index.html
+++ b/mandemos_frontend/public/index.html
@@ -1,1 +1,62 @@
-<!DOCTYPE html><html><head><title>MandemOS</title></head><body><h1>MandemOS Clone Active</h1></body></html>
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>MandemOS</title>
+    <style>
+      body {
+        font-family: sans-serif;
+        background-color: #000;
+        color: #fff;
+        text-align: center;
+        padding-top: 2em;
+      }
+      #responseBox {
+        white-space: pre-line;
+        border: 1px solid #555;
+        padding: 0.5em;
+        width: 80%;
+        max-width: 600px;
+        margin: 1em auto;
+        min-height: 100px;
+      }
+      input[type="text"] {
+        width: 80%;
+        max-width: 400px;
+        margin: 0.5em auto;
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>MandemOS Clone Active</h1>
+    <div id="responseBox"></div>
+    <input id="textInput" type="text" placeholder="Type a message" />
+    <button id="sendBtn">Send</button>
+
+    <script>
+      document.getElementById('sendBtn').addEventListener('click', sendMessage);
+      document.getElementById('textInput').addEventListener('keypress', function(e) {
+        if (e.key === 'Enter') sendMessage();
+      });
+
+      async function sendMessage() {
+        const inputEl = document.getElementById('textInput');
+        const msg = inputEl.value.trim();
+        if (!msg) return;
+        inputEl.value = '';
+
+        try {
+          const res = await fetch('http://localhost:8080/talk', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ message: msg })
+          });
+          const data = await res.json();
+          document.getElementById('responseBox').innerText += data.reply + '\n';
+        } catch (err) {
+          document.getElementById('responseBox').innerText += 'Error: ' + err + '\n';
+        }
+      }
+    </script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- enhance the MandemOS frontend with a simple chat interface
- new response box shows replies from the backend API

## Testing
- `python -m py_compile $(git ls-files '*.py' | tr '\n' ' ')`

------
https://chatgpt.com/codex/tasks/task_e_688c98bbd5d0832f855d61f676e641ce