### PR TITLE
Add selfcode ability

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ This will start the API server directly from the zip file.
 ### Self Repair and Improvement
 Use `selfrepair:description` to attempt an automated fix of Hecate's own code based on the issue description. Similarly, `selfimprove:suggestion` asks Hecate to refactor itself with the provided suggestion. Both commands rely on your OpenAI API key and create a `.bak` backup of the current source before overwriting it if successful.
 
+You can also generate new scripts automatically using `selfcode:task|filename`. The task description is sent to ChatGPT and the resulting Python code is saved under `scripts/filename`.
+
 ### Self Improvement Lattice
 Hecate tracks ongoing improvements in a simple lattice stored in `lattice.json`.
 Use these commands to manage it:


### PR DESCRIPTION
## Summary
- extend Hecate with a `selfcode:` command
- implement `_self_generate_code` to create Python scripts via ChatGPT
- document the new command in README

## Testing
- `python -m py_compile "OK workspaces/hecate.py"`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_688caced0cec832f97153658eb719d4d