### PR TITLE
Add auto restart helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,9 @@ Both the CLI tools and the API server automatically read the key from these loca
    A health check endpoint is available at `http://localhost:8080/health`.
    Load balancers can poll this URL to verify the service is running.
 
-3. Open `index.html` in your browser. The page will communicate with the server running on `localhost:8080`.
+3. To automatically restart the server if it crashes, run `auto_restart.py` instead. It will relaunch the API whenever it exits with a non-zero status. Any additional arguments are passed through to `main.py`, e.g. `python auto_restart.py -b` to run in the background.
+
+4. Open `index.html` in your browser. The page will communicate with the server running on `localhost:8080`.
 
 ### Command Line Chat
 If you prefer to talk to Hecate directly in your terminal, run the small CLI utility:

--- a/auto_restart.py
+++ b/auto_restart.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+"""Helper to relaunch the API server if it crashes."""
+
+import os
+import subprocess
+import sys
+import time
+
+SCRIPT_PATH = os.path.join(os.path.dirname(__file__), 'OK workspaces', 'main.py')
+
+
+def main() -> None:
+    """Launch ``main.py`` and restart it if the process exits with an error."""
+    cmd = [sys.executable, SCRIPT_PATH, *sys.argv[1:]]
+    while True:
+        process: subprocess.Popen | None = None
+        try:
+            process = subprocess.Popen(cmd)
+            ret = process.wait()
+        except KeyboardInterrupt:
+            if process and process.poll() is None:
+                process.terminate()
+            break
+        if ret == 0:
+            break
+        print(
+            f"Server exited with status {ret}, restarting in 5 seconds...",
+            flush=True,
+        )
+        time.sleep(5)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `auto_restart.py` to automatically relaunch the API server if it exits unexpectedly
- document the new script in the *Run Locally* section of the README
- refine restart helper for more robust interrupts and pass-through args

## Testing
- `python -m py_compile auto_restart.py`
- `python -m py_compile "OK workspaces/main.py"`


------
https://chatgpt.com/codex/tasks/task_e_688c97188078832fa1523e041a97e324