### PR TITLE
Fix static path for frontend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ __pycache__/
 openai_key.txt
 mandemos.db
 conversation.log
+mandemos_frontend/node_modules/
+mandemos_frontend/package-lock.json

--- a/README.md
+++ b/README.md
@@ -236,3 +236,9 @@ can be used alongside the Flask API.
    The page will be available at `http://localhost:3000` and should display
    **"MandemOS Clone Active"**.
 
+### Chat UI
+For a simple ChatGPT-style interface that talks to the Hecate API, start the
+front-end server and then visit `http://localhost:3000/chat_ui.html` in your
+browser. The page sends messages to the `/talk` endpoint and displays the
+conversation in a familiar chat format.
+

--- a/mandemos_frontend/public/chat_ui.html
+++ b/mandemos_frontend/public/chat_ui.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="UTF-8">
+  <title>ChatGPT Style Chat</title>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      background: #343541;
+      color: #ececf1;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+    #chat {
+      flex: 1;
+      overflow-y: auto;
+      padding: 1rem;
+    }
+    .message {
+      max-width: 600px;
+      margin: 0 auto 1rem;
+      padding: 0.75rem 1rem;
+      border-radius: 4px;
+    }
+    .user {
+      background: #2b2c32;
+      text-align: right;
+    }
+    .bot {
+      background: #454653;
+      text-align: left;
+    }
+    #input-area {
+      display: flex;
+      padding: 1rem;
+      background: #40414f;
+    }
+    #input-area input {
+      flex: 1;
+      padding: 0.5rem;
+      font-size: 1rem;
+      border: none;
+      border-radius: 4px;
+      background: #343541;
+      color: #ececf1;
+    }
+    #input-area button {
+      margin-left: 0.5rem;
+      padding: 0.5rem 1rem;
+      font-size: 1rem;
+      border: none;
+      border-radius: 4px;
+      background: #19c37d;
+      color: white;
+      cursor: pointer;
+    }
+  </style>
+</head>
+<body>
+  <div id="chat"></div>
+  <div id="input-area">
+    <input type="text" id="userInput" placeholder="Send a message" />
+    <button onclick="sendMessage()">Send</button>
+  </div>
+
+  <script>
+    const chat = document.getElementById('chat');
+    const input = document.getElementById('userInput');
+
+    function appendMessage(text, className) {
+      const div = document.createElement('div');
+      div.className = 'message ' + className;
+      div.textContent = text;
+      chat.appendChild(div);
+      chat.scrollTop = chat.scrollHeight;
+    }
+
+    async function sendMessage() {
+      const text = input.value.trim();
+      if (!text) return;
+      appendMessage(text, 'user');
+      input.value = '';
+      try {
+        const res = await fetch('http://localhost:8080/talk', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ message: text })
+        });
+        const data = await res.json();
+        appendMessage(data.reply, 'bot');
+      } catch (err) {
+        appendMessage('Error: ' + err.message, 'bot');
+      }
+    }
+
+    input.addEventListener('keypress', e => {
+      if (e.key === 'Enter') {
+        sendMessage();
+      }
+    });
+  </script>
+</body>
+</html>

--- a/mandemos_frontend/server.js
+++ b/mandemos_frontend/server.js
@@ -3,7 +3,13 @@ const path = require('path');
 const app = express();
 const PORT = 3000;
 
-app.use(express.static('public'));
+// Serve static files relative to this script's directory so the
+// server works even when launched from another path
+app.use(express.static(path.join(__dirname, 'public')));
+// Explicit route for the chat UI to keep the old chat.html path working
+app.get('/chat.html', (req, res) => {
+  res.sendFile(path.resolve(__dirname, 'public', 'chat_ui.html'));
+});
 app.get('*', (req, res) => {
   res.sendFile(path.resolve(__dirname, 'public', 'index.html'));
 });


### PR DESCRIPTION
## Summary
- adjust the Express static directory to use an absolute path
- allow `chat.html` to load correctly even if the server is launched from another working directory


------
https://chatgpt.com/codex/tasks/task_e_688c94e79ae4832fbff7f6a6c351da5d